### PR TITLE
sed: new link for x64 version, the version is still 4.9

### DIFF
--- a/bucket/sed.json
+++ b/bucket/sed.json
@@ -5,11 +5,11 @@
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mbuilov/sed-windows/releases/download/sed-4.9/sed-4.9-x64.exe#/sed.exe",
-            "hash": "55252fc023b7092d8f39b209a33ae2d56558a541ea6606af53e00c37f1296163"
+            "url": "https://github.com/mbuilov/sed-windows/releases/download/sed-4.9-x64-fixed/sed-4.9-x64.exe#/sed.exe",
+            "hash": "38fbdb237afaf25fdaee462c6504d61ce7dd122db0206b353df1a29e5b0aa7c5"
         },
         "32bit": {
-            "url": "https://github.com/mbuilov/sed-windows/releases/download/sed-4.9/sed-4.9-x86.exe#/sed.exe",
+            "url": "https://github.com/mbuilov/sed-windows/releases/download/sed-4.9-x64-fixed/sed-4.9-x86.exe#/sed.exe",
             "hash": "7b31b07ebffa675f85b27908e9f3eb8ef57ec297c289942f6cd2a40eee8f88b3"
         }
     },


### PR DESCRIPTION
New link for x64 version: in the repo there is a fixed binary for x64 architecture.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
